### PR TITLE
Add aws-sdk-v1 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in capify-v3-ec2.gemspec
 gemspec
+gem 'aws-sdk-v1'


### PR DESCRIPTION
This code base uses the AWS namespace from the aws-sdk-v1 gem, so it makes sense to put it in the Gemfile